### PR TITLE
Wine 7.0 Install for Ubuntu 22.04 (Jammy Jellyfish)

### DIFF
--- a/wine7installUbuntu22.sh
+++ b/wine7installUbuntu22.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#This enables 32bit architecture
+sudo dpkg --add-architecture i386
+
+#This downloads the security key
+wget -nc https://dl.winehq.org/wine-builds/winehq.key
+
+#This moves the security key to the correct place
+sudo mv winehq.key /usr/share/keyrings/winehq-archive.key
+
+#This adds WineHQ repository to the sources list
+wget -nc https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
+
+#This adds the winehq repository for version 7 to the repository list
+sudo mv winehq-jammy.sources /etc/apt/sources.list.d
+
+#This updates everything
+sudo apt update
+
+#This installs wine version 7
+sudo apt install --install-recommends winehq-stable
+
+#Subject to GPLv3 License Copyright Nicolas Matthews 2022


### PR DESCRIPTION
WineHQ has changed how to install Wine7.0 and Wine in general so I am making an updated version of the scripts.

Check the file version for older versions of the scripts.